### PR TITLE
Removed --now from dokku installation

### DIFF
--- a/uninstall
+++ b/uninstall
@@ -4,4 +4,4 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 PLUGIN="$1"
 
-[[ "$PLUGIN" = "monit" ]] && systemctl disable dokku-monit.service --now
+[[ "$PLUGIN" = "monit" ]] && systemctl disable dokku-monit.service


### PR DESCRIPTION
On debian, there is no `--now` option for systemctl. Thus it makes dokku unable to remove the plugin. Not sure if this is a requirement on some linux distro's, but if it's not then it's better not to add this option.

Fixes:
systemctl: unrecognized option '--now'