### PR TITLE
Fixed building app config in recent Dokku.

### DIFF
--- a/post-config-update
+++ b/post-config-update
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/monit/functions"
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/functions"
-
-monit_build_app_config "$APP"
+monit_build_app_config "$@"
 monit_reload


### PR DESCRIPTION
This now uses the passed app name instead of the APP env variable similar to https://github.com/dokku/dokku/blob/b4ebd3bd75b7eb3d40a3a99dc00eeab8d56fd3d6/plugins/nginx-vhosts/post-domains-update#L18 and should fix using the plugin in recent Dokku versions.