### PR TITLE
Let's Encrypt dokku plugin support

### DIFF
--- a/templates/monit.sigil
+++ b/templates/monit.sigil
@@ -2,7 +2,7 @@
 check host {{ .APP }} with address {{ .ADDRESS }}
   restart program = "{{ .DOKKU_BIN }} ps:restart {{ .APP }}" with timeout {{ default 120 .RESTART_TIMEOUT }} seconds
   if failed
-     port {{ default 80 .PORT }}
+     port {{ if eq .SCHEME "https" }}443 {{ else if .PORT }}{{ .PORT }} {{ else }}80 {{end}}
      protocol {{ .SCHEME }}
      http headers [Host: {{ .DOMAIN }}]
      request "{{ default "/" .REQUEST }}"


### PR DESCRIPTION
I modified the `monit.sigil` template in order to make this plugin able to work **out of the box** together with the [**Let's Encrypt plugin**](https://github.com/dokku/dokku-letsencrypt).

Before this change, the plugin would fail in monitoring apps working in https thanks to that plugin.
The change is pretty much self explanatory (I hope).

I hope you will find it useful!