### PR TITLE
Move dokku-monit.service to /etc/systemd/system/

### DIFF
--- a/dependencies
+++ b/dependencies
@@ -21,7 +21,9 @@ enable_systemd_unit() {
     local plugin_path="$PLUGIN_AVAILABLE_PATH/monit"
 
     if hash systemctl 2> /dev/null; then
-        systemctl is-enabled dokku-monit.service > /dev/null 2>&1 || systemctl enable "$plugin_path/dokku-monit.service" --now
+        cp -f "$plugin_path/dokku-monit.service" /etc/systemd/system/
+        systemctl reenable dokku-monit.service
+        systemctl start dokku-monit.service
     else
         echo >&2 "Could not install systemd unit because systemctl was not found."
         return 1

--- a/install
+++ b/install
@@ -5,7 +5,9 @@ enable_systemd_unit() {
     local plugin_path="$PLUGIN_AVAILABLE_PATH/monit"
 
     if hash systemctl 2> /dev/null; then
-        systemctl is-enabled dokku-monit.service > /dev/null 2>&1 || systemctl enable "$plugin_path/dokku-monit.service" --now
+        cp -f "$plugin_path/dokku-monit.service" /etc/systemd/system/
+        systemctl reenable dokku-monit.service
+        systemctl start dokku-monit.service
     else
         echo >&2 "Could not install systemd unit because systemctl was not found."
         return 1


### PR DESCRIPTION
Hey! We had an issue that the folder where `dokku-monit.service` was located, was on a different partition than the root folder and that caused problems with `systemd`. Better explanation here - https://github.com/systemd/systemd/issues/8307.

Copying `dokku-monit.service` to `/etc/systemd/system/` fixes the problem. A lot of dokku services do that as well.